### PR TITLE
Adding support for one secrets file

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,45 @@ If MY_VARIABLE consists of multiple variables, decode it using
   const secrets = JSON.parse(decrypted);
 ```
 
+### Using one secret file for multiple stages
+
+Rather than having one secret file per stage, you can have one secret file with multiple stages.
+
+Add the `perStage` configuration parameters to your `serverless.yml` configuration file.
+
+```yml
+custom:
+  serverless-kms-secrets:
+    secretsFile: kms-secrets.yml
+    filePerStage: false # true = one file per stage, false = one file, defaults to true
+  kmsSecrets: ${file(kms-secrets.yml)}
+```
+
+Specify the `stage` when encrypting the variable.
+
+```
+sls encrypt -n VARIABLE_NAME -v myvalue [-k keyId] --stage
+```
+
+The encrypt command will also use the `provider.stage` value in the `serverless.yml` configuration file.
+
+```yml
+provider:
+  stage: ${opt:stage, env:stage, 'dev'}
+```
+
+```
+sls encrypt -n VARIABLE_NAME:SECRET_NAME -v myvalue [-k keyId]
+```
+
+Reference the stage when using the variable in the `provider.environment` section of the `serverless.yml` configuration file.
+
+```yml
+  environment:
+    MY_VARIABLE: ${self:custom.kmsSecrets.${self:provider.stage}.secrets.MY_VARIABLE}
+```
+
+
 ## TODO
 
 * Add support for sls deploy (deploy as KMS encrypted environment variables)

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ prd:
 Reference the stage when using the variable in the `provider.environment` section of the `serverless.yml` configuration file.
 
 ```yml
+provider:
   environment:
     MY_VARIABLE: ${self:custom.kmsSecrets.${self:provider.stage}.secrets.VARIABLE_NAME}
 ```

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ custom:
 Specify the `stage` when encrypting the variable.
 
 ```
-sls encrypt -n VARIABLE_NAME -v myvalue [-k keyId] --stage
+sls encrypt -n VARIABLE_NAME -v myvalue [-k keyId] --stage dev
 ```
 
 The encrypt command will also use the `provider.stage` value in the `serverless.yml` configuration file.
@@ -145,7 +145,20 @@ provider:
 ```
 
 ```
-sls encrypt -n VARIABLE_NAME:SECRET_NAME -v myvalue [-k keyId]
+sls encrypt -n VARIABLE_NAME -v myvalue [-k keyId]
+```
+
+Your `kms-secrets.yml` file has the stage in the first level.
+
+```yml
+dev:
+  secrets:
+    VARIABLE_NAME: encrypted_data
+  keyArn: key_arn
+prd:
+  secrets:
+    VARIABLE_NAME: encrypted_data
+  keyArn: key_arn
 ```
 
 Reference the stage when using the variable in the `provider.environment` section of the `serverless.yml` configuration file.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Reference the stage when using the variable in the `provider.environment` sectio
 
 ```yml
   environment:
-    MY_VARIABLE: ${self:custom.kmsSecrets.${self:provider.stage}.secrets.MY_VARIABLE}
+    MY_VARIABLE: ${self:custom.kmsSecrets.${self:provider.stage}.secrets.VARIABLE_NAME}
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -111,12 +111,10 @@ class kmsSecretsPlugin {
           region = this.options.region || inited.provider.region;
           stage = this.options.stage || inited.provider.stage;
 
-          console.log('moduleConfig', moduleConfig);
           const configFile =
             moduleConfig.secretsFile
               || `kms-secrets.${stage}.${region}.yml`;
           const { filePerStage = true } = moduleConfig;
-          console.log('filePerStage', filePerStage);
           let kmsSecrets = {
             secrets: {},
           };
@@ -126,7 +124,6 @@ class kmsSecretsPlugin {
           if (fse.existsSync(configFile)) {
             configData = yaml.load(configFile);
             kmsSecrets = filePerStage ? configData : configData[stage];
-            console.log(kmsSecrets);
             if (!keyId) {
               keyId = kmsSecrets.keyArn.replace(/.*\//, '');
               myModule.serverless.cli.log(`Encrypting using key ${keyId} found in ${configFile}`);

--- a/index.js
+++ b/index.js
@@ -121,7 +121,6 @@ class kmsSecretsPlugin {
         };
         let keyId = this.options.keyid;
         let configData = {};
-        console.log('kmsSecrets', kmsSecrets);
 
         if (fse.existsSync(configFile)) {
           configData = yaml.load(configFile);

--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ class kmsSecretsPlugin {
         const defaultConfigFileSingle = `kms-secrets.${region}.yml`;
         const configFile =
           moduleConfig.secretsFile
-            || (filePerStage ?  defaultConfigFileStage : defaultConfigFileSingle);
+            || (filePerStage ? defaultConfigFileStage : defaultConfigFileSingle);
         let kmsSecrets = {
           secrets: {},
         };
@@ -124,13 +124,11 @@ class kmsSecretsPlugin {
 
         if (fse.existsSync(configFile)) {
           configData = yaml.load(configFile);
-          //kmsSecrets = filePerStage ? configData : configData[stage];
+          // kmsSecrets = filePerStage ? configData : configData[stage];
           if (filePerStage) {
             kmsSecrets = configData;
-          } else {
-            if (stage in configData) {
-              kmsSecrets = configData[stage];
-            }
+          } else if (stage in configData) {
+            kmsSecrets = configData[stage];
           }
           if (!keyId) {
             keyId = kmsSecrets.keyArn.replace(/.*\//, '');

--- a/index.js
+++ b/index.js
@@ -66,14 +66,8 @@ class kmsSecretsPlugin {
     };
 
     this.hooks = {
-      'encrypt:kmsEncrypt': () => {
-        BbPromise.bind(this)
-          .then(this.encryptVariable);
-      },
-      'decrypt:kmsDecrypt': () => {
-        BbPromise.bind(this)
-          .then(this.decryptVariable);
-      },
+      'encrypt:kmsEncrypt': this.encryptVariable.bind(this),
+      'decrypt:kmsDecrypt': this.decryptVariable.bind(this),
     };
   }
 
@@ -94,152 +88,172 @@ class kmsSecretsPlugin {
   }
 
   encryptVariable() {
-    const myModule = this;
-    let stage = this.options.stage;
-    let region = this.options.region;
-    const parts = this.options.name.split(':');
-    const varname = parts[0];
-    const subvarname = parts[1];
-    let value = this.options.value;
+    return new Promise((resolve, reject) => {
+      const myModule = this;
+      let stage = this.options.stage;
+      let region = this.options.region;
+      const parts = this.options.name.split(':');
+      const varname = parts[0];
+      const subvarname = parts[1];
+      let value = this.options.value;
 
-    this.serverless.service.load({
-      stage,
-      region,
-    })
-      .then((inited) => {
-        myModule.serverless.environment = inited.environment;
-        const vars = new myModule.serverless.classes.Variables(myModule.serverless);
-        return vars.populateService(this.options).then(() => inited);
+      this.serverless.service.load({
+        stage,
+        region,
       })
-      .then((inited) => {
-        const moduleConfig = inited.custom['serverless-kms-secrets'] || {};
-        region = this.options.region || inited.provider.region;
-        stage = this.options.stage || inited.provider.stage;
+        .then((inited) => {
+          myModule.serverless.environment = inited.environment;
+          const vars = new myModule.serverless.classes.Variables(myModule.serverless);
+          return vars.populateService(this.options).then(() => inited);
+        })
+        .then((inited) => {
+          const moduleConfig = inited.custom['serverless-kms-secrets'] || {};
+          region = this.options.region || inited.provider.region;
+          stage = this.options.stage || inited.provider.stage;
 
-        const configFile =
-          moduleConfig.secretsFile
-            || `kms-secrets.${stage}.${region}.yml`;
-        let kmsSecrets = {
-          secrets: {},
-        };
-        let keyId = this.options.keyid;
+          const configFile =
+            moduleConfig.secretsFile
+              || `kms-secrets.${stage}.${region}.yml`;
+          const perStage = moduleConfig.perStage || false;
+          console.log('perStage', perStage);
+          let kmsSecrets = {
+            secrets: {},
+          };
+          let configData;
+          let keyId = this.options.keyid;
 
-        if (fse.existsSync(configFile)) {
-          kmsSecrets = yaml.load(configFile);
-          if (!keyId) {
-            keyId = kmsSecrets.keyArn.replace(/.*\//, '');
-            myModule.serverless.cli.log(`Encrypting using key ${keyId} found in ${configFile}`);
+          if (fse.existsSync(configFile)) {
+            configData = yaml.load(configFile);
+            console.log('configData', configData);
+            kmsSecrets = perStage ? configData[stage]: configData;
+            console.log('kmsSecrets', kmsSecrets);
+            if (!keyId) {
+              keyId = kmsSecrets.keyArn.replace(/.*\//, '');
+              myModule.serverless.cli.log(`Encrypting using key ${keyId} found in ${configFile}`);
+            }
+          } else if (!this.options.keyid) {
+            myModule.serverless.cli.log(`No config file ${configFile} and no keyid specified`);
+            reject('No keyId in serverless.yml');
           }
-        } else if (!this.options.keyid) {
-          myModule.serverless.cli.log(`No config file ${configFile} and no keyid specified`);
-          return ('No keyId in serverless.yml');
-        }
 
-        function preEncrypt() {
-          return new Promise((succeed) => {
-            if (subvarname) {
-              if (kmsSecrets &&
-                  kmsSecrets.secrets &&
-                  kmsSecrets.secrets[varname]) {
-                myModule.decrypt(kmsSecrets.secrets[varname], region, stage)
-                  .then((valtext) => {
-                    succeed(JSON.parse(valtext));
-                  });
+          function preEncrypt() {
+            return new Promise((succeed) => {
+              if (subvarname) {
+                if (kmsSecrets &&
+                    kmsSecrets.secrets &&
+                    kmsSecrets.secrets[varname]) {
+                  myModule.decrypt(kmsSecrets.secrets[varname], region, stage)
+                    .then((valtext) => {
+                      succeed(JSON.parse(valtext));
+                    });
+                } else {
+                  succeed({});
+                }
               } else {
                 succeed({});
               }
-            } else {
-              succeed({});
-            }
-          });
-        }
+            });
+          }
 
-        return preEncrypt()
-          .then((valstruct) => {
-            if (subvarname) {
-              const newStruct = valstruct;
-              newStruct[subvarname] = value;
-              value = JSON.stringify(newStruct);
-            }
+          return preEncrypt()
+            .then((valstruct) => {
+              if (subvarname) {
+                const newStruct = valstruct;
+                newStruct[subvarname] = value;
+                value = JSON.stringify(newStruct);
+              }
 
-            myModule.serverless.getProvider('aws')
-              .request('KMS',
-                'encrypt',
-                {
-                  KeyId: keyId, // The identifier of the CMK to use for encryption.
-                  // You can use the key ID or Amazon Resource Name (ARN) of the CMK,
-                  // or the name or ARN of an alias that refers to the CMK.
-                  Plaintext: Buffer.from(String(value)), // eslint-disable-line new-cap
-                }, region, stage)
-              .then((data) => {
-                kmsSecrets.secrets[varname] = data.CiphertextBlob.toString('base64');
-                kmsSecrets.keyArn = data.KeyId;
-                fse.writeFileSync(configFile, yaml.stringify(kmsSecrets, 2));
-                myModule.serverless.cli.log(`Updated ${varname} to ${configFile}`);
-              }, (error) => {
-                myModule.serverless.cli.log(error);
-              });
-          });
-      }, (error) => {
-        myModule.serverless.cli.log(error);
-      });
+              myModule.serverless.getProvider('aws')
+                .request('KMS',
+                  'encrypt',
+                  {
+                    KeyId: keyId, // The identifier of the CMK to use for encryption.
+                    // You can use the key ID or Amazon Resource Name (ARN) of the CMK,
+                    // or the name or ARN of an alias that refers to the CMK.
+                    Plaintext: Buffer.from(String(value)), // eslint-disable-line new-cap
+                  }, region, stage)
+                .then((data) => {
+                  kmsSecrets.secrets[varname] = data.CiphertextBlob.toString('base64');
+                  kmsSecrets.keyArn = data.KeyId;
+                  if (perStage) {
+                    configData[stage] = kmsSecrets;
+                  } else {
+                    configData = kmsSecrets;
+                  }
+                  fse.writeFileSync(configFile, yaml.stringify(configData, 3, 2));
+                  myModule.serverless.cli.log(`Updated ${varname} to ${configFile}`);
+                  resolve();
+                }, (error) => {
+                  myModule.serverless.cli.log(error);
+                  reject(error);
+                });
+            });
+        }, (error) => {
+          myModule.serverless.cli.log(error);
+          reject(error);
+        });
+    });
   }
 
   // Decrypt a variable defined in the options
   decryptVariable() {
-    const myModule = this;
+    return new Promise((resolve, reject) => {
+      const myModule = this;
 
-    let stage = this.options.stage;
-    let region = this.options.region;
+      let stage = this.options.stage;
+      let region = this.options.region;
 
-    this.serverless.service.load({
-      stage,
-      region,
-    })
-      .then((inited) => {
-        myModule.serverless.environment = inited.environment;
-        const vars = new myModule.serverless.classes.Variables(myModule.serverless);
-        return vars.populateService(this.options).then(() => inited);
+      this.serverless.service.load({
+        stage,
+        region,
       })
-      .then((inited) => {
-        const moduleConfig = inited.custom['serverless-kms-secrets'] || {};
-        stage = this.options.stage || inited.provider.stage;
-        region = this.options.region || inited.provider.region;
+        .then((inited) => {
+          myModule.serverless.environment = inited.environment;
+          const vars = new myModule.serverless.classes.Variables(myModule.serverless);
+          return vars.populateService(this.options).then(() => inited);
+        })
+        .then((inited) => {
+          const moduleConfig = inited.custom['serverless-kms-secrets'] || {};
+          stage = this.options.stage || inited.provider.stage;
+          region = this.options.region || inited.provider.region;
 
-        const configFile =
-          moduleConfig.secretsFile
-            || `kms-secrets.${stage}.${region}.yml`;
-        myModule.serverless.cli.log(`Decrypting secrets from ${configFile}`);
+          const configFile =
+            moduleConfig.secretsFile
+              || `kms-secrets.${stage}.${region}.yml`;
+          myModule.serverless.cli.log(`Decrypting secrets from ${configFile}`);
 
-        readFile(configFile)
-          .then((secrets) => {
-            const names = this.options.name ? [this.options.name] : Object.keys(secrets);
-            names.forEach((varName) => {
-              const parts = varName.split(':');
-              const mainVarName = parts[0];
-              const subVarName = parts[1];
+          readFile(configFile)
+            .then((secrets) => {
+              const names = this.options.name ? [this.options.name] : Object.keys(secrets);
+              names.forEach((varName) => {
+                const parts = varName.split(':');
+                const mainVarName = parts[0];
+                const subVarName = parts[1];
 
-              if (secrets[mainVarName]) {
-                myModule.decrypt(secrets[mainVarName], region, stage)
-                  .then((secret) => {
-                    if (subVarName) {
-                      let varStruct = {};
-                      if (secret) {
-                        varStruct = JSON.parse(secret);
+                if (secrets[mainVarName]) {
+                  myModule.decrypt(secrets[mainVarName], region, stage)
+                    .then((secret) => {
+                      if (subVarName) {
+                        let varStruct = {};
+                        if (secret) {
+                          varStruct = JSON.parse(secret);
+                        }
+                        myModule.serverless.cli.log(`${varName} = ${varStruct[subVarName] || ''}`);
+                      } else {
+                        myModule.serverless.cli.log(`${varName} = ${secret}`);
                       }
-                      myModule.serverless.cli.log(`${varName} = ${varStruct[subVarName] || ''}`);
-                    } else {
-                      myModule.serverless.cli.log(`${varName} = ${secret}`);
-                    }
-                  }, (error) => {
-                    myModule.serverless.cli.log(`KMS error ${error}`);
-                  });
-              } else {
-                myModule.serverless.cli.log(`No secret with name ${varName}`);
-              }
-            });
-          }, error => myModule.serverless.cli.log(error));
-      }, error => myModule.serverless.cli.log(error));
+                    }, (error) => {
+                      myModule.serverless.cli.log(`KMS error ${error}`);
+                      reject(error);
+                    });
+                } else {
+                  myModule.serverless.cli.log(`No secret with name ${varName}`);
+                  resolve();
+                }
+              });
+            }, error => myModule.serverless.cli.log(error));
+        }, error => myModule.serverless.cli.log(error));
+    });
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kms-secrets",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "engines": {
     "node": ">=4.0"
   },

--- a/test/integration-multiple-stages-one-file.js
+++ b/test/integration-multiple-stages-one-file.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const Serverless = require('serverless');
+const execSync = require('child_process').execSync;
+const path = require('path');
+const fse = require('fs-extra');
+const expect = require('chai').expect;
+const testUtils = require('./testUtils');
+
+const serverless = new Serverless();
+serverless.init();
+const serverlessExec = path.join(serverless.config.serverlessPath, '..', 'bin', 'serverless');
+
+describe('integration with stage option', () => {
+  before(() => {
+    // create temporary directory and copy test service there
+    process.env.MOCHA_PLUGIN_TEST_DIR = path.join(__dirname);
+    const tmpDir = testUtils.getTmpDirPath();
+    fse.mkdirsSync(tmpDir);
+    fse.copySync(path.join(process.env.MOCHA_PLUGIN_TEST_DIR, 'test-service-multiple-stages-one-file'), tmpDir);
+    process.chdir(tmpDir);
+  });
+
+  it('should contain encrypt and decrypt params in cli info', () => {
+    const test = execSync(`${serverlessExec}`);
+    const result = new Buffer(test, 'base64').toString();
+    expect(result).to.have.string('encrypt ....................... Encrypt variables to file');
+    expect(result).to.have.string('decrypt ....................... Decrypt variables from file');
+    expect(result).to.have.string('kmsSecretsPlugin');
+  });
+
+  // it('should create test for hello function', () => {
+  //   const test = execSync(`${serverlessExec} encrypt -n MY_VARIABLE -v my-secret`);
+  //   const result = new Buffer(test, 'base64').toString();
+  // });
+});

--- a/test/integration-multiple-stages-one-file.js
+++ b/test/integration-multiple-stages-one-file.js
@@ -11,7 +11,7 @@ const serverless = new Serverless();
 serverless.init();
 const serverlessExec = path.join(serverless.config.serverlessPath, '..', 'bin', 'serverless');
 
-describe('integration with stage option', () => {
+describe('integration with filePerStage option', () => {
   before(() => {
     // create temporary directory and copy test service there
     process.env.MOCHA_PLUGIN_TEST_DIR = path.join(__dirname);

--- a/test/test-service-multiple-stages-one-file/.npmignore
+++ b/test/test-service-multiple-stages-one-file/.npmignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/test/test-service-multiple-stages-one-file/.serverless_plugins/serverless-kms-secrets/index.js
+++ b/test/test-service-multiple-stages-one-file/.serverless_plugins/serverless-kms-secrets/index.js
@@ -1,0 +1,9 @@
+// Proxy
+const path = require('path');
+
+if(!process.env.MOCHA_PLUGIN_TEST_DIR) {
+  process.env.MOCHA_PLUGIN_TEST_DIR = path.join(__dirname, '../../../');
+}
+
+const mochaDir = path.join(process.env.MOCHA_PLUGIN_TEST_DIR, '../', 'index.js');
+module.exports = require(mochaDir);

--- a/test/test-service-multiple-stages-one-file/handler.js
+++ b/test/test-service-multiple-stages-one-file/handler.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports.hello = (event, context, callback) => {
+  const response = {
+    statusCode: 200,
+    body: JSON.stringify({
+      message: 'Go Serverless v1.0! Your function executed successfully!',
+      input: event,
+    }),
+  };
+
+  callback(null, response);
+
+  // Use this code if you don't use the http event with the LAMBDA-PROXY integration
+  // callback(null, { message: 'Go Serverless v1.0! Your function executed successfully!', event });
+};

--- a/test/test-service-multiple-stages-one-file/serverless.yml
+++ b/test/test-service-multiple-stages-one-file/serverless.yml
@@ -1,0 +1,26 @@
+service: mocha-test-suite
+
+provider:
+  name: aws
+  runtime: nodejs6.10
+  environment:
+    STAGE: ${opt:stage, self:provider.stage}-stage-test
+    MY_VARIABLE: ${self:custom.kmsSecrets.secrets.MY_VARIABLE}
+#  iamRoleStatements:
+#    - Effect: Allow
+#      Action:
+#      - KMS:Decrypt
+#      Resource: ${self:custom.kmsSecrets.keyArn}
+
+functions:
+  hello:
+    handler: handler.hello
+
+plugins:
+  - serverless-kms-secrets
+
+custom:
+  serverless-kms-secrets:
+    keyId: id
+    kmsSecrets: ${file(kms-secrets.yml)}
+    filePerStage: false


### PR DESCRIPTION
This is a great plugin!

I have multiple stages and do not want to confuse our developers by having a dozen secret files. This PR adds the functionality to have only one secret file with multiple stages within it.

```
dev:
  secrets:
    VARIABLE_NAME: encrypted_data
  keyArn: key_arn
prd:
  secrets:
    VARIABLE_NAME: encrypted_data
  keyArn: key_arn
```

When do you think this update can get published into npm? I would like to use it for a production project. Thanks!

Ref: https://github.com/nordcloud/serverless-kms-secrets/issues/24